### PR TITLE
Web Project Specification: Add GET to `/logout` specification

### DIFF
--- a/Project/Specification-Web.md
+++ b/Project/Specification-Web.md
@@ -75,6 +75,7 @@ Requirements and Constraints:
 |  |  | This page lists all available tickets. Information including the quantity of each ticket, the owner's email, and the price, for tickets that are not expired. |
 |  |  | This page contains a form that a user can submit new tickets for sell. Fields: name, quantity, price, expiration date |
 |  |  | This page contains a form that a user can buy new tickets. Fields: name, quantity |
+|  |  | This page contains a form that a user can update existing tickets. Fields: name, quantity, price, expiration date |
 |  |  | The ticket-selling form can be posted to /sell |
 |  |  | The ticket-buying form can be posted to /buy |
 |  |  | The ticket-update form can be posted to /update |

--- a/Project/Specification-Web.md
+++ b/Project/Specification-Web.md
@@ -107,7 +107,7 @@ Requirements and Constraints:
 |  |  | For any errors, redirect back to / and show an error message |
 |  |  |  |
 |  |  |  |
-| R7 | /logout | [POST] |
+| R7 | /logout | [GET, POST] |
 |  |  | Logout will invalid the current session and redirect to the login page. After logout, the user shouldn't be able to access restricted pages. |
 |  |  |  |
 | R8 | /* | [any] |


### PR DESCRIPTION
Modify the `/logout` specification to accept the GET method in addition to the POST method. This allows the logout event to occur by navigating the web browser to `/logout` instead of requiring a form submission.